### PR TITLE
Add Equation Forge 24 game with GameShell sprint/survival modes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import ExponentSprint from "./pages/ExponentSprint";
 import Landing from "./pages/Landing";
 import NumberSenseSprint from "./pages/NumberSenseSprint";
 import PrimeFactorChallenge from "./pages/PrimeFactorChallenge";
+import TwentyFourGame from "./pages/TwentyFourGame";
 
 export default function App() {
   return (
@@ -15,6 +16,7 @@ export default function App() {
         <Route path="/games/exponent-sprint" element={<ExponentSprint />} />
         <Route path="/games/number-sense-sprint" element={<NumberSenseSprint />} />
         <Route path="/games/prime-factor-challenge" element={<PrimeFactorChallenge />} />
+        <Route path="/games/equation-forge-24" element={<TwentyFourGame />} />
         <Route path="/games/coming-soon" element={<ComingSoon />} />
       </Routes>
     </BrowserRouter>

--- a/src/components/landing/LandingGallery.tsx
+++ b/src/components/landing/LandingGallery.tsx
@@ -45,6 +45,19 @@ export default function LandingGallery() {
         </Link>
       </article>
 
+
+      <article className={styles.card}>
+        <div className={styles.thumb} aria-hidden="true">
+          <span>(a+b)×c</span>
+        </div>
+        <h2>Equation Forge 24</h2>
+        <p>Combine four numbers with arithmetic operators and parentheses to craft exactly 24.</p>
+        <Link to="/games/equation-forge-24">
+          <span>&#9654;</span>
+          Play now
+        </Link>
+      </article>
+
       <article className={styles.card}>
         <div className={styles.thumb} aria-hidden="true">
           <span>

--- a/src/games/twenty-four/TwentyFourGame.module.css
+++ b/src/games/twenty-four/TwentyFourGame.module.css
@@ -1,0 +1,73 @@
+.questionWrap {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.numberTile {
+  min-width: 3.5rem;
+  min-height: 3.5rem;
+  border-radius: 0.85rem;
+  border: 1px solid color-mix(in srgb, var(--line) 78%, transparent);
+  background:
+    radial-gradient(circle at 30% 20%, color-mix(in srgb, var(--mint) 12%, transparent), transparent 60%),
+    linear-gradient(145deg, color-mix(in srgb, var(--surface-elevated) 88%, var(--surface) 12%), var(--surface));
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 55%, transparent),
+    0 12px 28px color-mix(in srgb, var(--text) 10%, transparent);
+  display: grid;
+  place-items: center;
+  font-size: 1.3rem;
+  font-weight: 700;
+}
+
+.hint {
+  margin-top: 0.85rem;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.inputLayout {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.expressionInput {
+  width: 100%;
+  border-radius: 0.9rem;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, var(--surface-elevated) 90%, transparent);
+  color: var(--text);
+  padding: 0.8rem 0.95rem;
+  font-size: 1rem;
+  letter-spacing: 0.01em;
+}
+
+.expressionInput:focus {
+  outline: 2px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  outline-offset: 2px;
+}
+
+.helpRow {
+  color: var(--muted);
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.submitButton {
+  justify-self: center;
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: white;
+  background: linear-gradient(135deg, var(--accent), var(--violet));
+}
+
+.submitButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}

--- a/src/games/twenty-four/TwentyFourGame.tsx
+++ b/src/games/twenty-four/TwentyFourGame.tsx
@@ -1,0 +1,6 @@
+import GameShell from "../../components/GameShell";
+import { twentyFourGameDefinition } from "./definition";
+
+export default function TwentyFourGame() {
+  return <GameShell definition={twentyFourGameDefinition} />;
+}

--- a/src/games/twenty-four/definition.test.tsx
+++ b/src/games/twenty-four/definition.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { twentyFourGameDefinition } from "./definition";
+
+describe("twenty four game definition", () => {
+  test("maps difficulty level to deterministic generation", () => {
+    const question = twentyFourGameDefinition.generateQuestion({
+      rng: () => 0.99,
+      difficultyLevel: 6,
+      previousQuestion: null,
+    });
+
+    expect(question.numbers.every((value) => value >= 1 && value <= 13)).toBe(true);
+  });
+
+  test("validates correct and invalid answers", () => {
+    const question = {
+      numbers: [3, 3, 8, 8] as [number, number, number, number],
+      text: "3 • 3 • 8 • 8",
+      solution: "(8/(3-(8/3)))",
+    };
+
+    const correct = twentyFourGameDefinition.evaluateAnswer({ question, answer: "8/(3-(8/3))" });
+    expect(correct.kind).toBe("correct");
+
+    const invalid = twentyFourGameDefinition.evaluateAnswer({ question, answer: "(8*3)-3" });
+    expect(invalid.kind).toBe("invalid");
+  });
+});

--- a/src/games/twenty-four/definition.tsx
+++ b/src/games/twenty-four/definition.tsx
@@ -1,0 +1,74 @@
+import type { GameDefinition } from "../../game-shell/types";
+import { evaluateTwentyFourExpression, generateQuestionForDifficulty, isTwentyFour, type TwentyFourQuestion } from "./logic";
+import styles from "./TwentyFourGame.module.css";
+
+export const twentyFourGameDefinition: GameDefinition<TwentyFourQuestion, string, string> = {
+  gameId: "equation-forge-24",
+  title: "Equation Forge 24",
+  subtitle: "Use all four numbers once with +, -, ×, ÷ and parentheses to hit 24.",
+  createInitialAnswer: () => "",
+  generateQuestion: ({ rng, difficultyLevel, previousQuestion }) =>
+    generateQuestionForDifficulty(rng, difficultyLevel ?? 1, previousQuestion),
+  evaluateAnswer: ({ question, answer }) => {
+    const result = evaluateTwentyFourExpression(answer, question);
+    if (!result.valid) {
+      return {
+        kind: "invalid",
+        message: result.message ?? "Invalid expression.",
+      };
+    }
+
+    if (result.value && isTwentyFour(result.value)) {
+      return {
+        kind: "correct",
+        normalizedAnswer: answer.trim(),
+      };
+    }
+
+    return {
+      kind: "wrong",
+      normalizedAnswer: answer.trim(),
+    };
+  },
+  renderQuestion: (question) => {
+    if (!question) return "Press Start";
+
+    return (
+      <div>
+        <div className={styles.questionWrap}>
+          {question.numbers.map((number, index) => (
+            <div key={`${number}-${index}`} className={styles.numberTile}>
+              {number}
+            </div>
+          ))}
+        </div>
+        <div className={styles.hint}>Build an expression that equals 24</div>
+      </div>
+    );
+  },
+  getCorrectAnswerLabel: (question) => question.solution,
+  getQuestionLabel: (question) => question.text,
+  renderAnswerInput: ({ value, onChange, onSubmit, disabled }) => (
+    <div className={styles.inputLayout}>
+      <input
+        type="text"
+        className={styles.expressionInput}
+        placeholder="Example: (8/(3-(8/3)))"
+        autoComplete="off"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            onSubmit();
+          }
+        }}
+        disabled={disabled}
+      />
+      <div className={styles.helpRow}>Allowed: + - * / parentheses, and each number exactly once.</div>
+      <button type="button" className={styles.submitButton} onClick={onSubmit} disabled={disabled || !value.trim()}>
+        Submit Expression
+      </button>
+    </div>
+  ),
+};

--- a/src/games/twenty-four/logic.test.ts
+++ b/src/games/twenty-four/logic.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+import { evaluateTwentyFourExpression, findSolutionExpression, generateQuestionForDifficulty, isTwentyFour } from "./logic";
+
+function createRng(values: number[]) {
+  let index = 0;
+  return () => {
+    const value = values[index % values.length];
+    index += 1;
+    return value;
+  };
+}
+
+describe("generateQuestionForDifficulty", () => {
+  test("produces solvable starter questions", () => {
+    const question = generateQuestionForDifficulty(createRng([0.2, 0.3, 0.4, 0.5]), 1);
+    expect(findSolutionExpression(question.numbers)).not.toBeNull();
+    expect(question.numbers.every((value) => value >= 1 && value <= 6)).toBe(true);
+  });
+
+  test("higher difficulties include card-range values", () => {
+    const question = generateQuestionForDifficulty(createRng([0.99]), 7);
+    expect(question.numbers.every((value) => value >= 1 && value <= 13)).toBe(true);
+  });
+});
+
+describe("evaluateTwentyFourExpression", () => {
+  const question = {
+    numbers: [3, 3, 8, 8] as [number, number, number, number],
+    text: "3 • 3 • 8 • 8",
+    solution: "(8/(3-(8/3)))",
+  };
+
+  test("accepts a correct expression", () => {
+    const result = evaluateTwentyFourExpression("8/(3-(8/3))", question);
+    expect(result.valid).toBe(true);
+    expect(result.value && isTwentyFour(result.value)).toBe(true);
+  });
+
+  test("rejects expressions that do not use each number once", () => {
+    const result = evaluateTwentyFourExpression("(8*3)-3", question);
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain("exactly once");
+  });
+
+  test("rejects malformed expressions", () => {
+    const result = evaluateTwentyFourExpression("8/(3-)", question);
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain("parse");
+  });
+});

--- a/src/games/twenty-four/logic.ts
+++ b/src/games/twenty-four/logic.ts
@@ -1,0 +1,397 @@
+export type TwentyFourQuestion = {
+  numbers: [number, number, number, number];
+  text: string;
+  solution: string;
+};
+
+type Fraction = {
+  numerator: number;
+  denominator: number;
+};
+
+type SolveState = {
+  value: Fraction;
+  expression: string;
+};
+
+type DifficultyConfig = {
+  min: number;
+  max: number;
+};
+
+const TARGET_VALUE = 24;
+const MAX_GENERATION_ATTEMPTS = 250;
+
+const DIFFICULTY_TABLE: Record<number, DifficultyConfig> = {
+  1: { min: 1, max: 6 },
+  2: { min: 1, max: 8 },
+  3: { min: 1, max: 10 },
+  4: { min: 1, max: 13 },
+};
+
+function normalizeDifficultyLevel(difficultyLevel: number) {
+  if (!Number.isFinite(difficultyLevel)) return 1;
+  return Math.max(1, Math.floor(difficultyLevel));
+}
+
+function difficultyConfigForLevel(level: number): DifficultyConfig {
+  const normalized = normalizeDifficultyLevel(level);
+  if (normalized <= 1) return DIFFICULTY_TABLE[1];
+  if (normalized === 2) return DIFFICULTY_TABLE[2];
+  if (normalized === 3) return DIFFICULTY_TABLE[3];
+  return DIFFICULTY_TABLE[4];
+}
+
+function gcd(a: number, b: number): number {
+  let x = Math.abs(a);
+  let y = Math.abs(b);
+  while (y !== 0) {
+    const next = x % y;
+    x = y;
+    y = next;
+  }
+  return x || 1;
+}
+
+function reduceFraction(value: Fraction): Fraction {
+  if (value.denominator === 0) {
+    return value;
+  }
+
+  const sign = value.denominator < 0 ? -1 : 1;
+  const numerator = value.numerator * sign;
+  const denominator = value.denominator * sign;
+  const divisor = gcd(numerator, denominator);
+  return {
+    numerator: numerator / divisor,
+    denominator: denominator / divisor,
+  };
+}
+
+function add(a: Fraction, b: Fraction): Fraction {
+  return reduceFraction({
+    numerator: a.numerator * b.denominator + b.numerator * a.denominator,
+    denominator: a.denominator * b.denominator,
+  });
+}
+
+function subtract(a: Fraction, b: Fraction): Fraction {
+  return reduceFraction({
+    numerator: a.numerator * b.denominator - b.numerator * a.denominator,
+    denominator: a.denominator * b.denominator,
+  });
+}
+
+function multiply(a: Fraction, b: Fraction): Fraction {
+  return reduceFraction({
+    numerator: a.numerator * b.numerator,
+    denominator: a.denominator * b.denominator,
+  });
+}
+
+function divide(a: Fraction, b: Fraction): Fraction | null {
+  if (b.numerator === 0) return null;
+  return reduceFraction({
+    numerator: a.numerator * b.denominator,
+    denominator: a.denominator * b.numerator,
+  });
+}
+
+function isTargetValue(value: Fraction) {
+  return value.denominator !== 0 && value.numerator === TARGET_VALUE * value.denominator;
+}
+
+function formatQuestionNumbers(numbers: [number, number, number, number]) {
+  return numbers.join(" • ");
+}
+
+function sortSignature(numbers: readonly number[]) {
+  return [...numbers].sort((a, b) => a - b).join(",");
+}
+
+export function randomInt(min: number, max: number, rng: () => number = Math.random) {
+  return Math.floor(rng() * (max - min + 1)) + min;
+}
+
+function searchSolution(states: SolveState[]): string | null {
+  if (states.length === 1) {
+    return isTargetValue(states[0].value) ? states[0].expression : null;
+  }
+
+  for (let i = 0; i < states.length; i += 1) {
+    for (let j = i + 1; j < states.length; j += 1) {
+      const left = states[i];
+      const right = states[j];
+      const rest = states.filter((_, index) => index !== i && index !== j);
+
+      const operations: Array<SolveState | null> = [
+        {
+          value: add(left.value, right.value),
+          expression: `(${left.expression}+${right.expression})`,
+        },
+        {
+          value: subtract(left.value, right.value),
+          expression: `(${left.expression}-${right.expression})`,
+        },
+        {
+          value: subtract(right.value, left.value),
+          expression: `(${right.expression}-${left.expression})`,
+        },
+        {
+          value: multiply(left.value, right.value),
+          expression: `(${left.expression}*${right.expression})`,
+        },
+        divide(left.value, right.value)
+          ? {
+              value: divide(left.value, right.value) as Fraction,
+              expression: `(${left.expression}/${right.expression})`,
+            }
+          : null,
+        divide(right.value, left.value)
+          ? {
+              value: divide(right.value, left.value) as Fraction,
+              expression: `(${right.expression}/${left.expression})`,
+            }
+          : null,
+      ];
+
+      for (const result of operations) {
+        if (!result) continue;
+        const solved = searchSolution([...rest, result]);
+        if (solved) return solved;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function findSolutionExpression(numbers: [number, number, number, number]): string | null {
+  const initial: SolveState[] = numbers.map((value) => ({
+    value: { numerator: value, denominator: 1 },
+    expression: String(value),
+  }));
+  return searchSolution(initial);
+}
+
+export function generateQuestionForDifficulty(
+  rng: () => number = Math.random,
+  difficultyLevel: number = 1,
+  previousQuestion: TwentyFourQuestion | null = null
+): TwentyFourQuestion {
+  const config = difficultyConfigForLevel(difficultyLevel);
+  const previousSignature = previousQuestion ? sortSignature(previousQuestion.numbers) : null;
+
+  let fallbackQuestion: TwentyFourQuestion | null = null;
+
+  for (let attempt = 0; attempt < MAX_GENERATION_ATTEMPTS; attempt += 1) {
+    const candidate: [number, number, number, number] = [
+      randomInt(config.min, config.max, rng),
+      randomInt(config.min, config.max, rng),
+      randomInt(config.min, config.max, rng),
+      randomInt(config.min, config.max, rng),
+    ];
+
+    if (previousSignature && sortSignature(candidate) === previousSignature) {
+      continue;
+    }
+
+    const solution = findSolutionExpression(candidate);
+    if (!solution) continue;
+
+    const question: TwentyFourQuestion = {
+      numbers: candidate,
+      text: formatQuestionNumbers(candidate),
+      solution,
+    };
+
+    if (!fallbackQuestion) {
+      fallbackQuestion = question;
+    }
+
+    return question;
+  }
+
+  if (fallbackQuestion) {
+    return fallbackQuestion;
+  }
+
+  const guaranteed: [number, number, number, number] = [3, 3, 8, 8];
+  return {
+    numbers: guaranteed,
+    text: formatQuestionNumbers(guaranteed),
+    solution: "(8/(3-(8/3)))",
+  };
+}
+
+type ParseResult = {
+  valid: boolean;
+  value?: Fraction;
+  usedNumbers?: number[];
+  message?: string;
+};
+
+type Token =
+  | { type: "number"; value: number }
+  | { type: "operator"; value: "+" | "-" | "*" | "/" }
+  | { type: "lparen" }
+  | { type: "rparen" };
+
+function tokenize(rawExpression: string): { tokens: Token[]; error: string | null } {
+  const tokens: Token[] = [];
+
+  for (let index = 0; index < rawExpression.length; ) {
+    const char = rawExpression[index];
+
+    if (char.trim() === "") {
+      index += 1;
+      continue;
+    }
+
+    if (/[0-9]/.test(char)) {
+      let end = index + 1;
+      while (end < rawExpression.length && /[0-9]/.test(rawExpression[end])) {
+        end += 1;
+      }
+      const value = Number(rawExpression.slice(index, end));
+      tokens.push({ type: "number", value });
+      index = end;
+      continue;
+    }
+
+    if (char === "+" || char === "-" || char === "*" || char === "/") {
+      tokens.push({ type: "operator", value: char });
+      index += 1;
+      continue;
+    }
+
+    if (char === "(") {
+      tokens.push({ type: "lparen" });
+      index += 1;
+      continue;
+    }
+
+    if (char === ")") {
+      tokens.push({ type: "rparen" });
+      index += 1;
+      continue;
+    }
+
+    return {
+      tokens: [],
+      error: `Unsupported character: ${char}`,
+    };
+  }
+
+  return { tokens, error: null };
+}
+
+export function evaluateTwentyFourExpression(rawExpression: string, question: TwentyFourQuestion): ParseResult {
+  const expression = rawExpression.trim();
+  if (!expression) {
+    return { valid: false, message: "Enter an expression before submitting." };
+  }
+
+  const { tokens, error } = tokenize(expression);
+  if (error) {
+    return { valid: false, message: error };
+  }
+
+  let index = 0;
+  const usedNumbers: number[] = [];
+
+  const parseExpression = (): Fraction | null => {
+    let value = parseTerm();
+    if (!value) return null;
+
+    while (index < tokens.length && tokens[index].type === "operator" && (tokens[index].value === "+" || tokens[index].value === "-")) {
+      const operator = tokens[index].value;
+      index += 1;
+      const right = parseTerm();
+      if (!right) return null;
+      value = operator === "+" ? add(value, right) : subtract(value, right);
+    }
+
+    return value;
+  };
+
+  const parseTerm = (): Fraction | null => {
+    let value = parseFactor();
+    if (!value) return null;
+
+    while (index < tokens.length && tokens[index].type === "operator" && (tokens[index].value === "*" || tokens[index].value === "/")) {
+      const operator = tokens[index].value;
+      index += 1;
+      const right = parseFactor();
+      if (!right) return null;
+      if (operator === "*") {
+        value = multiply(value, right);
+      } else {
+        const quotient = divide(value, right);
+        if (!quotient) return null;
+        value = quotient;
+      }
+    }
+
+    return value;
+  };
+
+  const parseFactor = (): Fraction | null => {
+    const token = tokens[index];
+    if (!token) return null;
+
+    if (token.type === "number") {
+      index += 1;
+      usedNumbers.push(token.value);
+      return { numerator: token.value, denominator: 1 };
+    }
+
+    if (token.type === "operator" && token.value === "-") {
+      index += 1;
+      const value = parseFactor();
+      if (!value) return null;
+      return reduceFraction({ numerator: -value.numerator, denominator: value.denominator });
+    }
+
+    if (token.type === "lparen") {
+      index += 1;
+      const value = parseExpression();
+      if (!value) return null;
+      if (tokens[index]?.type !== "rparen") {
+        return null;
+      }
+      index += 1;
+      return value;
+    }
+
+    return null;
+  };
+
+  const value = parseExpression();
+  if (!value || index !== tokens.length) {
+    return {
+      valid: false,
+      message: "Could not parse expression. Use numbers, + - * /, and parentheses.",
+    };
+  }
+
+  const required = [...question.numbers].sort((a, b) => a - b).join(",");
+  const provided = [...usedNumbers].sort((a, b) => a - b).join(",");
+
+  if (required !== provided) {
+    return {
+      valid: false,
+      message: "Use each of the 4 numbers exactly once.",
+    };
+  }
+
+  return {
+    valid: true,
+    value,
+    usedNumbers,
+  };
+}
+
+export function isTwentyFour(value: Fraction) {
+  return isTargetValue(value);
+}

--- a/src/pages/TwentyFourGame.tsx
+++ b/src/pages/TwentyFourGame.tsx
@@ -1,0 +1,5 @@
+import TwentyFourGame from "../games/twenty-four/TwentyFourGame";
+
+export default function TwentyFourGamePage() {
+  return <TwentyFourGame />;
+}


### PR DESCRIPTION
## Summary
- add a new `Equation Forge 24` game under `src/games/twenty-four/` built on the shared `GameShell`
- implement deterministic puzzle generation by difficulty with guaranteed solvable 4-number sets and previous-question avoidance
- implement safe expression parsing/evaluation for `+ - * /` and parentheses, validating that players use each of the 4 provided numbers exactly once
- add a custom polished input/number-tile UI for the new game
- wire the game into routing (`/games/equation-forge-24`) and the landing gallery card list
- add unit tests for generation/evaluation logic and game-definition behavior

## Notes
- local tooling dependencies are currently missing in this environment (`vite` / `vitest` binaries unavailable), so runtime and test execution were not successful here.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c7ef7f944832fab6bc11850296a27)